### PR TITLE
Make `inspector` async

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
 # Creates a CLI command that invokes the entry-point function 
 [project.scripts]
 # command = entry-point
-inspector = "inspector.main:main"
+inspector = "inspector.main:main_entry"
 
 [project.urls]
 "Homepage" = "https://github.com/OpenZeppelin/openzeppelin-inspector"

--- a/src/inspector/detector_tester/test_runner.py
+++ b/src/inspector/detector_tester/test_runner.py
@@ -353,7 +353,7 @@ def format_differences_json(results: dict[str, ScannerResults]) -> str:
     return json.dumps(differences, indent=2)
 
 
-def scan_with_single_detector_test_project(
+async def scan_with_single_detector_test_project(
     detector_name: str,
     test_project_name: str,
     test_files: list[Path],
@@ -410,7 +410,7 @@ def scan_with_single_detector_test_project(
             logger.info(f"Stripped test annotation from {len(clean_files)} test files")
 
             # Run the scan on the clean files using the temporary project directory
-            response = ScannerManager().execute_scan(
+            response = await ScannerManager().execute_scan(
                 [detector_name], clean_files, temp_project_dir, scanners
             )
 
@@ -448,7 +448,7 @@ def scan_with_single_detector_test_project(
         # Run the scan directly on the original test files
         logger.info(f"Testing with original test files (clean_projects=False)")
 
-        response = ScannerManager().execute_scan(
+        response = await ScannerManager().execute_scan(
             [detector_name], test_files, test_dir, scanners
         )
 
@@ -570,7 +570,7 @@ def create_detector_test_report(
     return report
 
 
-def run_detector_tests(
+async def run_detector_tests(
     scanners: list[str],
     detectors: list[str],
     leave_test_annotations: bool = False,
@@ -658,7 +658,7 @@ def run_detector_tests(
             )
 
             # Scan with this detector and test_project
-            per_test_project_findings = scan_with_single_detector_test_project(
+            per_test_project_findings = await scan_with_single_detector_test_project(
                 detector_name,
                 test_project_name,
                 test_files,

--- a/src/inspector/main.py
+++ b/src/inspector/main.py
@@ -299,6 +299,7 @@ async def main():
 
 def main_entry():
     import asyncio
+
     asyncio.run(main())
 
 

--- a/src/inspector/main.py
+++ b/src/inspector/main.py
@@ -297,5 +297,10 @@ async def main():
         raise SystemExit()
 
 
-if __name__ == "__main__":
+def main_entry():
+    import asyncio
     asyncio.run(main())
+
+
+if __name__ == "__main__":
+    main_entry()

--- a/src/inspector/main.py
+++ b/src/inspector/main.py
@@ -298,8 +298,6 @@ async def main():
 
 
 def main_entry():
-    import asyncio
-
     asyncio.run(main())
 
 

--- a/src/inspector/main.py
+++ b/src/inspector/main.py
@@ -37,6 +37,7 @@ from .detector_tester import run_detector_tests, NoTestFilesDiscoveredError
 from .scan_executor import ScanExecutor
 from . import scanner_registry
 
+
 async def main():
     """Fetch args and run the scan."""
 

--- a/src/inspector/main.py
+++ b/src/inspector/main.py
@@ -3,6 +3,7 @@ from .setup_logging import initialize_logging
 
 initialize_logging()
 
+import asyncio
 import os
 import json
 from time import time
@@ -25,7 +26,6 @@ from .cli.capabilities.exceptions import (
 )
 from .response_finalizer import responses_finalizer
 
-
 from .composer import FindingComposer
 from .helpers import (
     get_version_info,
@@ -37,8 +37,7 @@ from .detector_tester import run_detector_tests, NoTestFilesDiscoveredError
 from .scan_executor import ScanExecutor
 from . import scanner_registry
 
-
-def main():
+async def main():
     """Fetch args and run the scan."""
 
     # start timing how long the program takes to execute
@@ -179,7 +178,7 @@ def main():
     elif args.mode == "test":
         status_spinner.start("Running tests... this may take a while...")
         try:
-            test_results, test_has_failures, test_report = run_detector_tests(
+            test_results, test_has_failures, test_report = await run_detector_tests(
                 args.scanners,
                 args.detector_names,
                 args.leave_test_annotations,
@@ -210,7 +209,7 @@ def main():
                 scanners=args.scanners,
             )
             # execute the scan
-            scanner_responses = scan_executor.execute()
+            scanner_responses = await scan_executor.execute()
             # Complete the responses
             finalized_scanner_responses, finalized_scanned_files = responses_finalizer(
                 scanner_responses
@@ -298,4 +297,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/src/inspector/scan_executor.py
+++ b/src/inspector/scan_executor.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import List, Dict, Optional
 
 from .models._complete.scanner_response import CompleteScannerResponse
 from .scanner_manager import ScannerManager
@@ -12,10 +13,10 @@ class ScanExecutor:
 
     def __init__(
         self,
-        detectors_names: list[str],
-        source_code: list[str],
+        detectors_names: List[str],
+        source_code: List[str],
         project_root: str,
-        scanners: list[str] = None,
+        scanners: Optional[List[str]] = None,
     ):
         self.detectors_names = detectors_names
         self.source_code = source_code
@@ -23,7 +24,7 @@ class ScanExecutor:
         self.scanners = scanners or []
         self.scanner_manager = ScannerManager()
 
-    def execute(self) -> dict[str, CompleteScannerResponse]:
+    async def execute(self) -> dict[str, CompleteScannerResponse]:
         """
         Execute the scanning process using the configured rules and scanners.
 
@@ -38,7 +39,7 @@ class ScanExecutor:
                 else Path(self.project_root)
             )
             source_code_paths = [Path(path) for path in self.source_code]
-            scanner_manager_scanner_responses = self.scanner_manager.execute_scan(
+            scanner_manager_scanner_responses = await self.scanner_manager.execute_scan(
                 self.detectors_names,
                 source_code_paths,
                 project_root_path,

--- a/src/inspector/scan_executor.py
+++ b/src/inspector/scan_executor.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import Optional
 
 from .models._complete.scanner_response import CompleteScannerResponse
 from .scanner_manager import ScannerManager
@@ -13,10 +13,10 @@ class ScanExecutor:
 
     def __init__(
         self,
-        detectors_names: List[str],
-        source_code: List[str],
+        detectors_names: list[str],
+        source_code: list[str],
         project_root: str,
-        scanners: Optional[List[str]] = None,
+        scanners: Optional[list[str]] = None,
     ):
         self.detectors_names = detectors_names
         self.source_code = source_code

--- a/src/inspector/scanner_manager.py
+++ b/src/inspector/scanner_manager.py
@@ -106,6 +106,7 @@ class AbstractScannerRunner(abc.ABC):
     ) -> MinimalScannerResponse:
         pass
 
+
 class PythonScannerRunner(AbstractScannerRunner):
     def __init__(self, scanner: BaseScanner, scanner_dir: str):
         self._scanner = scanner
@@ -161,9 +162,7 @@ class ExecutableScannerRunner(AbstractScannerRunner):
 
         try:
             process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
+                *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
             )
             stdout, stderr = await process.communicate()
 

--- a/src/inspector/scanner_manager.py
+++ b/src/inspector/scanner_manager.py
@@ -16,6 +16,7 @@ Environment Variables:
     INSPECTOR_SCANNERS: Colon-separated paths to additional scanner locations
 """
 
+import asyncio
 import json
 import os
 import logging
@@ -26,6 +27,7 @@ import subprocess
 import sys
 import importlib
 import traceback
+from typing import List, Dict
 from .constants import PATH_USER_INSPECTOR_SCANNERS_VENVS
 from .models.minimal.scanner_response import MinimalScannerResponse
 from .models._complete.scanner_response import CompleteScannerResponse
@@ -99,11 +101,10 @@ class AbstractScannerRunner(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def run(
+    async def run(
         self, detector_names: list[str], code_paths: list[Path], project_root: Path
     ) -> MinimalScannerResponse:
         pass
-
 
 class PythonScannerRunner(AbstractScannerRunner):
     def __init__(self, scanner: BaseScanner, scanner_dir: str):
@@ -122,11 +123,11 @@ class PythonScannerRunner(AbstractScannerRunner):
         with VenvPathManager.temporary_venv_path(self._venvs_dir, self._scanner_dir):
             return self._scanner.get_root_test_dirs()
 
-    def run(
+    async def run(
         self, detector_names: list[str], code_paths: list[Path], project_root: Path
     ) -> MinimalScannerResponse:
         with VenvPathManager.temporary_venv_path(self._venvs_dir, self._scanner_dir):
-            return self._scanner.run(detector_names, code_paths, project_root)
+            return await self._scanner.run(detector_names, code_paths, project_root)
 
 
 class ExecutableScannerRunner(AbstractScannerRunner):
@@ -138,14 +139,14 @@ class ExecutableScannerRunner(AbstractScannerRunner):
     def get_scanner_name(self) -> str:
         return self._scanner_name
 
-    def get_supported_detector_metadata(self) -> dict[str, dict]:
+    def get_supported_detector_metadata(self) -> Dict[str, Dict]:
         return self._scanner_info.get("detectors", {})
 
-    def get_root_test_dirs(self) -> list[Path]:
+    def get_root_test_dirs(self) -> List[Path]:
         return []
 
-    def run(
-        self, detector_names: list[str], code_paths: list[Path], project_root: Path
+    async def run(
+        self, detector_names: List[str], code_paths: List[Path], project_root: Path
     ) -> MinimalScannerResponse:
         scanner_executable = self._scanner_path / "scanner"
         cmd = [
@@ -159,8 +160,19 @@ class ExecutableScannerRunner(AbstractScannerRunner):
         ]
 
         try:
-            process = subprocess.run(cmd, capture_output=True, text=True, check=True)
-            raw_output = json.loads(process.stdout)
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+
+            if process.returncode != 0:
+                raise subprocess.CalledProcessError(
+                    process.returncode or 1, cmd, output=stdout, stderr=stderr
+                )
+
+            raw_output = json.loads(stdout)
 
             return self._parse_scanner_output(raw_output)
 
@@ -233,12 +245,12 @@ class ScannerManager:
         cls()._initialize_scanners()
         cls._initialized = True
 
-    def execute_scan(
+    async def execute_scan(
         self,
-        detector_names: list[str],
-        code: list[Path],
+        detector_names: List[str],
+        code: List[Path],
         project_root: Path,
-        scanners: list[str] | None = None,
+        scanners: List[str] | None = None,
     ) -> dict[str, CompleteScannerResponse]:
         """
         Execute specified detectors using specified scanners (or else all scanners).
@@ -265,7 +277,7 @@ class ScannerManager:
             if scanner_name not in scanners:
                 continue
             try:
-                scanner_minimal_response = runner.run(
+                scanner_minimal_response = await runner.run(
                     detector_names, code, project_root
                 )
                 scanner_full_response = expand_response_minimal_to_full(

--- a/src/inspector/scanner_manager.py
+++ b/src/inspector/scanner_manager.py
@@ -27,7 +27,6 @@ import subprocess
 import sys
 import importlib
 import traceback
-from typing import List, Dict
 from .constants import PATH_USER_INSPECTOR_SCANNERS_VENVS
 from .models.minimal.scanner_response import MinimalScannerResponse
 from .models._complete.scanner_response import CompleteScannerResponse
@@ -140,14 +139,14 @@ class ExecutableScannerRunner(AbstractScannerRunner):
     def get_scanner_name(self) -> str:
         return self._scanner_name
 
-    def get_supported_detector_metadata(self) -> Dict[str, Dict]:
+    def get_supported_detector_metadata(self) -> dict[str, dict]:
         return self._scanner_info.get("detectors", {})
 
-    def get_root_test_dirs(self) -> List[Path]:
+    def get_root_test_dirs(self) -> list[Path]:
         return []
 
     async def run(
-        self, detector_names: List[str], code_paths: List[Path], project_root: Path
+        self, detector_names: list[str], code_paths: list[Path], project_root: Path
     ) -> MinimalScannerResponse:
         scanner_executable = self._scanner_path / "scanner"
         cmd = [
@@ -246,10 +245,10 @@ class ScannerManager:
 
     async def execute_scan(
         self,
-        detector_names: List[str],
-        code: List[Path],
+        detector_names: list[str],
+        code: list[Path],
         project_root: Path,
-        scanners: List[str] | None = None,
+        scanners: list[str] | None = None,
     ) -> dict[str, CompleteScannerResponse]:
         """
         Execute specified detectors using specified scanners (or else all scanners).

--- a/src/inspector/scanner_registry.py
+++ b/src/inspector/scanner_registry.py
@@ -11,6 +11,7 @@ The registry is loaded once when the module is imported and can be reloaded on d
 import json
 import logging
 from pathlib import Path
+from typing import List, Dict, Optional
 from .constants import PATH_USER_INSPECTOR_SCANNERS_REGISTRY
 
 _logger = logging.getLogger(__name__)
@@ -118,7 +119,7 @@ def get_installed_scanner_names() -> list[str]:
     return list(_registry.keys())
 
 
-def get_scanner_info(scanner_name: str) -> dict | None:
+def get_scanner_info(scanner_name: str) -> Optional[Dict]:
     """
     Get metadata for a specific scanner by name.
 
@@ -323,10 +324,10 @@ def get_detectors_by_criteria(
 
 
 def get_scanners_by_criteria(
-    detectors: list[str] | None = None,
-    tags: list[str] | None = None,
-    severities: list[str] | None = None,
-) -> list[dict]:
+    detectors: List[str] | None = None,
+    tags: List[str] | None = None,
+    severities: List[str] | None = None,
+) -> List:
     """
     Retrieve scanners matching the specified detectors, tags, or severities.
 
@@ -356,6 +357,7 @@ def get_scanners_by_criteria(
             matching_scanners.append({**scanner_info, "name": scanner_name})
             break
 
+    # FIXME clarify the return type and this function usage
     return sorted(matching_scanners, key=lambda x: x["name"])
 
 

--- a/src/inspector/scanner_registry.py
+++ b/src/inspector/scanner_registry.py
@@ -11,7 +11,7 @@ The registry is loaded once when the module is imported and can be reloaded on d
 import json
 import logging
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import Optional
 from .constants import PATH_USER_INSPECTOR_SCANNERS_REGISTRY
 
 _logger = logging.getLogger(__name__)
@@ -119,7 +119,7 @@ def get_installed_scanner_names() -> list[str]:
     return list(_registry.keys())
 
 
-def get_scanner_info(scanner_name: str) -> Optional[Dict]:
+def get_scanner_info(scanner_name: str) -> Optional[dict]:
     """
     Get metadata for a specific scanner by name.
 
@@ -324,10 +324,10 @@ def get_detectors_by_criteria(
 
 
 def get_scanners_by_criteria(
-    detectors: List[str] | None = None,
-    tags: List[str] | None = None,
-    severities: List[str] | None = None,
-) -> List:
+    detectors: list[str] | None = None,
+    tags: list[str] | None = None,
+    severities: list[str] | None = None,
+) -> list:
     """
     Retrieve scanners matching the specified detectors, tags, or severities.
 

--- a/src/inspector/scanners/base_scanner.py
+++ b/src/inspector/scanners/base_scanner.py
@@ -72,6 +72,7 @@ class ScanException(ScannerException):
 
     pass
 
+
 class BaseScanner(ABC):
     """
     Abstract base class defining the interface for single-file code scanners.

--- a/src/inspector/scanners/base_scanner.py
+++ b/src/inspector/scanners/base_scanner.py
@@ -72,7 +72,6 @@ class ScanException(ScannerException):
 
     pass
 
-
 class BaseScanner(ABC):
     """
     Abstract base class defining the interface for single-file code scanners.
@@ -184,7 +183,7 @@ class BaseScanner(ABC):
         pass
 
     @abstractmethod
-    def run(
+    async def run(
         self,
         detector_names: list[str],
         code_paths: list[Path],

--- a/src/inspector_cli.py
+++ b/src/inspector_cli.py
@@ -1,5 +1,6 @@
 import sys
 from inspector.main import main
+import asyncio
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(asyncio.run(main()))

--- a/tests/test_scanner_manager.py
+++ b/tests/test_scanner_manager.py
@@ -6,13 +6,11 @@ from logging import Logger
 from pathlib import Path
 
 from inspector.scanner_manager import ScannerManager, PythonScannerRunner
-from inspector.scanners import BaseScanner
-
 
 logger: Logger = logging.getLogger(__name__)
 
 
-class TestScannerManager(unittest.TestCase):
+class TestScannerManager(unittest.IsolatedAsyncioTestCase):
     MOCK_SCANNER_PATH = "tests/utils/mock_scanner"
 
     @classmethod
@@ -78,11 +76,11 @@ class TestScannerManager(unittest.TestCase):
             any(detector["id"].startswith("mock") for detector in metadata.values())
         )
 
-    def test_scanner_execution(self):
+    async def test_scanner_execution(self):
         """Test executing mock scanner on a test file."""
         manager = ScannerManager()
         test_file = Path("tests/utils/files/TestContract.sol")
-        results = manager.execute_scan(
+        results = await manager.execute_scan(
             ["mock-test-detector"], [test_file], test_file.parent, ["mock-scanner"]
         )
         self.assertIn("mock-scanner", results)

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -18,7 +18,7 @@ from inspector.detector_tester.test_runner import (
 )
 
 
-class TestTestRunner(unittest.TestCase):
+class TestTestRunner(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
         self.test_file = Path(self.temp_dir) / "test.sol"
@@ -245,7 +245,7 @@ class TestTestRunner(unittest.TestCase):
         self.assertNotIn(":true-negative-here:", cleaned)
         self.assertNotIn(":temporarily-invert-detector-test:", cleaned)
 
-    def test_run_detector_tests_with_no_detectors(self):
+    async def test_run_detector_tests_with_no_detectors(self):
         """Test running tests with no available detectors."""
         with patch(
             "inspector.detector_tester.test_runner.ScannerManager"
@@ -260,7 +260,7 @@ class TestTestRunner(unittest.TestCase):
             mock_test_manager_instance.get_test_projects.return_value = []
             mock_test_manager.return_value = mock_test_manager_instance
 
-            output, has_failures, report = run_detector_tests(
+            output, has_failures, report = await run_detector_tests(
                 scanners=["test_scanner"], detectors=["test_detector"]
             )
             self.assertEqual(output, "No detectors available to test")

--- a/tests/utils/mock_scanner/src/mock_scanner/main.py
+++ b/tests/utils/mock_scanner/src/mock_scanner/main.py
@@ -79,7 +79,7 @@ class MockScanner(BaseScanner):
 
         return cls._cached_root_test_dirs
 
-    def run(
+    async def run(
         self,
         detector_names: list[str],
         code_paths: list[Path],


### PR DESCRIPTION
## Description

This PR updates the scanner execution infrastructure by making it `async`. The reason is to make `inspector` execution more performant and not wait for slow i/o tasks to be completed. This is especially reasonable when waiting for a response from slow remote HTTP servers.

## Python modules scanners

Python scanners most likely read from the disk or potentially perform some blocking operations (as network i/o). This is so, because they probably want to read project files from disk or somehow perform an analysis. Such modules are being loaded into the `inspector`'s process. This PR changes the `main` entry point by making it async, so this execution flow seamlessly works.

> What if a scanner is `sync` indeed?

It is ok, since calling `sync` functions from `async` functions is legit, but not vice versa.

## Binary executables scanners

Since a binary execution involves host function calls, they are considered slow because the operation itself is not executed in the `inspector`'s memory. That is why it is suggested not to wait until the external process is completed instead make an async call. Implemented [here](https://github.com/OpenZeppelin/openzeppelin-inspector/pull/10/files#diff-88accbfcefcf74aee682f7be939011af99b4a69e9bd6703b107d43bf04e58689R163-R175).


