### PR TITLE
Add `rye` projects support

### DIFF
--- a/src/inspector/cli/capabilities/helpers.py
+++ b/src/inspector/cli/capabilities/helpers.py
@@ -17,6 +17,8 @@ from .exceptions import DependencyInstallationError, ExtractionError, DownloadEr
 
 logger: Logger = logging.getLogger(__name__)
 
+DEPENDENCY_INSTALL_TIMEOUT = 600  # seconds (10 minutes)
+
 
 def _get_scanner_paths(scanner_name: str) -> Tuple[Path, Path]:
     """Returns the installation and venv paths for a scanner."""
@@ -61,7 +63,6 @@ def _restore_pyproject_dependencies(
     req_path: Path, logger: Logger, pip_path: Optional[Path] = None
 ) -> None:
     """A wrapper that can restore unmanaged (pip) and managed (rye / uv) Python projects"""
-    PIP_INSTALL_TIMEOUT = 600  # seconds (10 minutes)
     if pip_path:
         cmd = [
             str(pip_path),
@@ -80,7 +81,7 @@ def _restore_pyproject_dependencies(
             check=True,
             capture_output=True,
             text=True,
-            timeout=PIP_INSTALL_TIMEOUT,
+            timeout=DEPENDENCY_INSTALL_TIMEOUT,
             encoding="utf-8",
             errors="replace",
             cwd=req_path if not pip_path else None,

--- a/src/inspector/cli/capabilities/helpers.py
+++ b/src/inspector/cli/capabilities/helpers.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import enum
 import logging
 import shutil
 import urllib.request, urllib.error
@@ -86,14 +85,15 @@ def _restore_pyproject_dependencies(
             errors="replace",
             cwd=req_path if not pip_path else None,
         )
-        logger.debug(f"pip install requirements output:\n{result.stdout}")
+        package_manager_name = "pip" if pip_path else "rye"
+        logger.debug(f"{package_manager_name} install requirements output:\n{result.stdout}")
         if result.stderr:
-            logger.warning(f"pip install requirements stderr:\n{result.stderr}")
+            logger.warning(f"{package_manager_name} install requirements stderr:\n{result.stderr}")
         elif result.returncode == 0:
-            logger.info(f"pip install requirements succeeded")
+            logger.info(f"{package_manager_name} install requirements succeeded")
         else:
             logger.error(
-                f"pip install requirements failed with code {result.returncode}"
+                f"{package_manager_name} install requirements failed with code {result.returncode}"
             )
     except subprocess.CalledProcessError as e:
         raise DependencyInstallationError(

--- a/src/inspector/cli/capabilities/helpers.py
+++ b/src/inspector/cli/capabilities/helpers.py
@@ -1,16 +1,19 @@
+import os
+import subprocess
+import enum
 import logging
 import shutil
 import urllib.request, urllib.error
 import zipfile
 from logging import Logger
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 from ...constants import (
     PATH_USER_INSPECTOR_SCANNERS,
     PATH_USER_INSPECTOR_SCANNERS_VENVS,
 )
-from .exceptions import ExtractionError, DownloadError
+from .exceptions import DependencyInstallationError, ExtractionError, DownloadError
 
 
 logger: Logger = logging.getLogger(__name__)
@@ -38,6 +41,82 @@ def _remove_dir_or_link(path: Path) -> bool:
         logger.error(f"Failed to remove path {path}: {e}")
         return False
     return True
+
+
+def _get_pip_path(venv_path: Path) -> Path:
+    # Construct the path to the pip executable within the venv
+    if os.name == "nt":  # Windows
+        pip_path = venv_path / "Scripts" / "pip.exe"
+    else:  # Linux, macOS, etc.
+        pip_path = venv_path / "bin" / "pip"
+
+    if not pip_path or not pip_path.exists():
+        logger.error(f"Could not find pip executable at expected location: {pip_path}")
+        raise DependencyInstallationError(
+            f"Could not find pip executable in created venv: {venv_path}"
+        )
+    return pip_path
+
+
+def _restore_pyproject_dependencies(
+    req_path: Path, logger: Logger, pip_path: Optional[Path] = None
+) -> None:
+    """A wrapper that can restore unmanaged (pip) and managed (rye / uv) Python projects"""
+    PIP_INSTALL_TIMEOUT = 600  # seconds (10 minutes)
+    if pip_path:
+        cmd = [
+            str(pip_path),
+            "install",
+            "--disable-pip-version-check",
+            "--no-cache-dir",  # Avoid potential caching issues
+            "-r",
+            str(req_path),
+        ]
+    else:
+        cmd = ["rye", "sync", "-f"]
+    try:
+        result = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=PIP_INSTALL_TIMEOUT,
+            encoding="utf-8",
+            errors="replace",
+            cwd=req_path,
+        )
+        logger.debug(f"Running command: {' '.join(cmd)}")
+        result = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=PIP_INSTALL_TIMEOUT,
+            encoding="utf-8",
+            errors="replace",
+        )
+        logger.debug(f"pip install requirements output:\n{result.stdout}")
+        if result.stderr:
+            logger.warning(f"pip install requirements stderr:\n{result.stderr}")
+        elif result.returncode == 0:
+            logger.info(f"pip install requirements succeeded")
+        else:
+            logger.error(
+                f"pip install requirements failed with code {result.returncode}"
+            )
+    except subprocess.CalledProcessError as e:
+        raise DependencyInstallationError(
+            f"Failed installing deps from {req_path.name}: {e.stderr or e.stdout}"
+        )
+    except subprocess.TimeoutExpired:
+        raise DependencyInstallationError(
+            f"Timeout installing deps from {req_path.name}"
+        )
+    except Exception as e:
+        logger.error(f"Unexpected error installing requirements: {e}", exc_info=True)
+        raise DependencyInstallationError(
+            f"Unexpected error installing requirements from {req_path.name}: {str(e)}"
+        ) from e
 
 
 def _remove_existing_installation(scanner_name: str) -> bool:

--- a/src/inspector/cli/capabilities/helpers.py
+++ b/src/inspector/cli/capabilities/helpers.py
@@ -86,9 +86,13 @@ def _restore_pyproject_dependencies(
             cwd=req_path if not pip_path else None,
         )
         package_manager_name = "pip" if pip_path else "rye"
-        logger.debug(f"{package_manager_name} install requirements output:\n{result.stdout}")
+        logger.debug(
+            f"{package_manager_name} install requirements output:\n{result.stdout}"
+        )
         if result.stderr:
-            logger.warning(f"{package_manager_name} install requirements stderr:\n{result.stderr}")
+            logger.warning(
+                f"{package_manager_name} install requirements stderr:\n{result.stderr}"
+            )
         elif result.returncode == 0:
             logger.info(f"{package_manager_name} install requirements succeeded")
         else:

--- a/src/inspector/cli/capabilities/helpers.py
+++ b/src/inspector/cli/capabilities/helpers.py
@@ -75,16 +75,6 @@ def _restore_pyproject_dependencies(
     else:
         cmd = ["rye", "sync", "-f"]
     try:
-        result = subprocess.run(
-            cmd,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=PIP_INSTALL_TIMEOUT,
-            encoding="utf-8",
-            errors="replace",
-            cwd=req_path,
-        )
         logger.debug(f"Running command: {' '.join(cmd)}")
         result = subprocess.run(
             cmd,
@@ -94,6 +84,7 @@ def _restore_pyproject_dependencies(
             timeout=PIP_INSTALL_TIMEOUT,
             encoding="utf-8",
             errors="replace",
+            cwd=req_path if not pip_path else None,
         )
         logger.debug(f"pip install requirements output:\n{result.stdout}")
         if result.stderr:

--- a/src/inspector/cli/capabilities/scanners_python.py
+++ b/src/inspector/cli/capabilities/scanners_python.py
@@ -22,15 +22,16 @@ from .exceptions import (
     DependencyInstallationError,
 )
 from .helpers import (
+    _get_pip_path,
     _remove_dir_or_link,
     _remove_existing_installation,
+    _restore_pyproject_dependencies,
 )
 from .scanners_installable import InstallableScanner
 from ...scanner_manager import VenvPathManager
 
 logger: Logger = logging.getLogger(__name__)
 
-PIP_INSTALL_TIMEOUT = 600  # seconds (10 minutes)
 PIP_EDITABLE_INSTALL_TIMEOUT = 300  # seconds (5 minutes)
 # files that should never be copied from scanner source into the installation location
 SENSITIVE_PATTERNS = {
@@ -176,20 +177,7 @@ class PythonInstallableScanner(InstallableScanner):
         except Exception as e:
             raise DependencyInstallationError(f"Failed creating venv: {str(e)}")
 
-        # Construct the path to the pip executable within the venv
-        if os.name == "nt":  # Windows
-            pip_path = self.installer._venv_path / "Scripts" / "pip.exe"
-        else:  # Linux, macOS, etc.
-            pip_path = self.installer._venv_path / "bin" / "pip"
-
-        if not pip_path or not pip_path.exists():
-            logger.error(
-                f"Could not find pip executable at expected location: {pip_path}"
-            )
-            raise DependencyInstallationError(
-                f"Could not find pip executable in created venv: {self.installer._venv_path}"
-            )
-
+        pip_path = _get_pip_path(self.installer._venv_path)
         is_effective_develop = self.is_effective_develop()
         req_file_name = (
             "requirements-dev.txt" if is_effective_develop else "requirements.txt"
@@ -218,47 +206,16 @@ class PythonInstallableScanner(InstallableScanner):
 
         if req_path and req_path.is_file():
             logger.info(f"Installing dependencies from {req_path.name}")
-            cmd = [
-                str(pip_path),
-                "install",
-                "--disable-pip-version-check",
-                "--no-cache-dir",  # Avoid potential caching issues
-                "-r",
-                str(req_path),
-            ]
-            try:
-                logger.debug(f"Running command: {' '.join(cmd)}")
-                result = subprocess.run(
-                    cmd,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                    timeout=PIP_INSTALL_TIMEOUT,
-                    encoding="utf-8",
-                    errors="replace",
-                )
-                logger.debug(f"pip install requirements output:\n{result.stdout}")
-                if result.stderr:
-                    logger.warning(f"pip install requirements stderr:\n{result.stderr}")
-            except subprocess.CalledProcessError as e:
-                raise DependencyInstallationError(
-                    f"Failed installing deps from {req_path.name}: {e.stderr or e.stdout}"
-                )
-            except subprocess.TimeoutExpired:
-                raise DependencyInstallationError(
-                    f"Timeout installing deps from {req_path.name}"
-                )
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error installing requirements: {e}", exc_info=True
-                )
-                raise DependencyInstallationError(
-                    f"Unexpected error installing requirements from {req_path.name}: {str(e)}"
-                ) from e
+            _restore_pyproject_dependencies(req_path, logger, pip_path)
         else:
             logger.debug(
                 f"No suitable requirements file found, skipping pip install -r."
             )
+            logger.debug(f"Trying to install dependencies with `rye`")
+            try:
+                _restore_pyproject_dependencies(self.installer._install_path, logger)
+            except Exception as e:
+                logger.error(f"Failed installing dependencies with `rye`: {e}")
 
         # Always try to install the package itself using -e for Python scanners
         # This ensures the scanner code is runnable from the venv


### PR DESCRIPTION
This PR introduces a couple of helper functions and support for scanner `rye` projects that do not use `pip` for managing dependencies.