### PR TITLE
Upgrade required Python version to include python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "inspector"
 dynamic = ["version"]
 description = "An orchestartion framework for analysis of web3 projects and source code"
 readme = "README.md"
-requires-python = ">=3.12,<3.13"
+requires-python = ">=3.12,<3.14"
 authors = [
     { name = "Andrew D. Anderson", email = "34364155+CallMeGwei@users.noreply.github.com" },
     { name = "Josep Chetrit", email = "92144922+josepchetrit12@users.noreply.github.com" },


### PR DESCRIPTION
# Motivation
This product is used for our main dashboard to handle scans, and some of the core components use python 3.14.
This creates a version conflict, which can easily be solved by upgrading this version allowance